### PR TITLE
Prevent endless loops on Deploy tasks

### DIFF
--- a/src/main/resources/xldeploy/XLDeployClient.py
+++ b/src/main/resources/xldeploy/XLDeployClient.py
@@ -151,6 +151,10 @@ class XLDeployClient(object):
             task_state_response = self.http_request.get(get_task_status_url, contentType='application/xml')
             task_state_xml = task_state_response.getResponse()
             status = extract_state(task_state_xml)
+            
+            if not task_state_response.isSuccessful():
+                raise Exception("Failure to get task status: %s" % status)
+                
             print 'Task [%s] now in state [%s] \n' % (task_id, status)
             if fail_on_pause:
                 if status in (


### PR DESCRIPTION
Fix for issue #46. Throws an error if the status check call fails. Previously it would simply loop, since the error returned never matched any of the status criteria.